### PR TITLE
puppeteer インストール用変更

### DIFF
--- a/.github/workflows/main_connpass-updater.yml
+++ b/.github/workflows/main_connpass-updater.yml
@@ -23,15 +23,19 @@ jobs:
 
       - name: npm install, build, and test
         run: |
-          npm install
+          PUPPETEER_CACHE_DIR=$(pwd)/node_modules/puppeteer npm install
           npm run build --if-present
           npm run test --if-present
+          npm prune --production
+
+      - name: Zip artifact for deployment
+        run: zip release.zip ./* -qr
 
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v2
         with:
           name: node-app
-          path: .
+          path: release.zip
 
   deploy:
     runs-on: ubuntu-latest
@@ -53,4 +57,4 @@ jobs:
           app-name: 'connpass-updater'
           slot-name: 'Production'
           publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_0F3A090BD26C43A78B048AE6AA866852 }}
-          package: .
+          package: release.zip


### PR DESCRIPTION
puppeteer を適切にインストールするために、デフォルトのワークフローをいくつか変更

  - `npm install` の前に `PUPPETEER_CACHE_DIR=$(pwd)/node_modules/puppeteer` を付けて Chromium のバイナリーを `node_modules/puppeteer` 配下に保存
  - Chromium のバイナリーが膨大なファイルの数／サイズなので、一つの zip ファイルとしてJob 間で受け渡す
  - ついでに zip 化前に `npm prune --production` で devDependencies のファイルを削除